### PR TITLE
Molecular filtering

### DIFF
--- a/src/processing/postprocessing/DataReduction.m
+++ b/src/processing/postprocessing/DataReduction.m
@@ -35,7 +35,7 @@ classdef DataReduction < PostProcessing
                 
                 switch(this.imageGenerationMethod)
                     case 0
-                        [indicesList, pList] = ismember(this.peakList, spectrum.spectralChannels);
+                        [indicesList, pList] = ismember(this.peakDetails(:,2), spectrum.spectralChannels);
 
                         pList(pList == 0) = [];
                         intensities(indicesList) = spectrum.intensities(pList);
@@ -49,7 +49,7 @@ classdef DataReduction < PostProcessing
 %                         intensities(i)
                 end
                 
-                spectrum = SpectralData(this.peakList, intensities);
+                spectrum = SpectralData(this.peakDetails(:,2), intensities);
             end
         end
         

--- a/src/processing/postprocessing/DatacubeReduction.m
+++ b/src/processing/postprocessing/DatacubeReduction.m
@@ -309,7 +309,7 @@ classdef DatacubeReduction < DataReduction
                 
             end
             
-            dataRepresentationList = generateDataRepresentationList(this, dataRepresentation, this.peakList, data, rois);
+            dataRepresentationList = generateDataRepresentationList(this, dataRepresentation, this.peakDetails(:,2), data, rois);
         end
         
         function writeOutimzML(this, dataRepresentation)

--- a/src/processing/postprocessing/MemoryEfficientPCA.m
+++ b/src/processing/postprocessing/MemoryEfficientPCA.m
@@ -266,16 +266,16 @@ classdef MemoryEfficientPCA < DataReduction
                 if(this.processEntireDataset && pixelListIndex == 1)
                     projectedDataRepresentation.setData(scores{pixelListIndex}, coeff{pixelListIndex}, ...
                         RegionOfInterest(dataRepresentation.width, dataRepresentation.height), ...
-                        dataRepresentation.isRowMajor, peakList, [dataRepresentation.name ' (ME PCA)']);
+                        dataRepresentation.isRowMajor, this.peakDetails(:,2), [dataRepresentation.name ' (ME PCA)']);
                 elseif(this.processEntireDataset)
                     projectedDataRepresentation.setData(scores{pixelListIndex}, coeff{pixelListIndex}, rois{pixelListIndex-1}, ...
-                        dataRepresentation.isRowMajor, peakList, [rois{pixelListIndex-1}.getName() ' (ME PCA)']);
+                        dataRepresentation.isRowMajor, this.peakDetails(:,2), [rois{pixelListIndex-1}.getName() ' (ME PCA)']);
                 else
                     dataROI = RegionOfInterest(dataRepresentation.width, dataRepresentation.height);
                     dataROI.addPixels(and(rois{pixelListIndex}.getPixelMask(), dataRepresentation.regionOfInterest.getPixelMask()));
                     
                     projectedDataRepresentation.setData(scores{pixelListIndex}, coeff{pixelListIndex}, dataROI, ...
-                        dataRepresentation.isRowMajor, peakList, [rois{pixelListIndex}.getName() ' (ME PCA)']);
+                        dataRepresentation.isRowMajor, this.peakDetails(:,2), [rois{pixelListIndex}.getName() ' (ME PCA)']);
                 end
                 
                 dataRepresentationList.add(projectedDataRepresentation);


### PR DESCRIPTION
This code is an added function in the peak filtering tab of peak picking to perform filtering based on a predefined list of molecules. The user creates a two column excel file of molecules and monoisotopic masses to match against, an adduct list, ppm threshold for matching and the polarity. Peak matches are then displayed as molecules ad masses instead of masses in the spectrum display window (requires updates to the MOOGL as well). 


